### PR TITLE
Update .env + example to default to production and debug off

### DIFF
--- a/.env
+++ b/.env
@@ -40,9 +40,9 @@ ENABLE_BUTTON_EDITOR=true
 
 #Debug Settings=Changes if your page should display a full error description instead of a generic error 500.
 #=App_debug either true or false. You might want to change this to false after you're done installing, but it's very useful for troubleshooting.
-APP_DEBUG=true
+APP_DEBUG=false
 #=App_env either local or production. Change this to production if you set the value above to false.
-APP_ENV=local
+APP_ENV=production
 LOG_CHANNEL=stack
 LOG_LEVEL=debug
 #=Disables all routes and displays a Maintenance placeholder page.

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 APP_NAME=Laravel
-APP_ENV=local
+APP_ENV=production
 APP_KEY=
-APP_DEBUG=true
+APP_DEBUG=false
 APP_URL=http://localhost
 
 LOG_CHANNEL=stack


### PR DESCRIPTION
By default we should be on production, users can switch it to debug if they want, but users will just dump this download/install into their webservers so lets stick to safe defaults