### PR TITLE
AdminController Dead Link

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -451,7 +451,7 @@ public function SendTestMail(Request $request)
     //Shows config file editor page
     public function showFileEditor(request $request)
     {
-        return redirect('/panel/config');
+        return redirect('/admin/config');
     }
 
     //Saves advanced config


### PR DESCRIPTION
Line 454 had wrong link causing errors when updating .env via alternative config editor on admin settings. Now fixed and tested.