### PR TITLE
Fix: Check if button exists to prevent 500 error

### DIFF
--- a/resources/views/studio/links.blade.php
+++ b/resources/views/studio/links.blade.php
@@ -77,7 +77,7 @@ if (isset($_COOKIE['LinkCount'])) {
                                         @foreach($links as $link)
                                         @php $button = Button::find($link->button_id); if(isset($button->name)){$buttonName = $button->name;}else{$buttonName = 0;} @endphp
                                         @php if($buttonName == "default email"){$buttonName = "email";} if($buttonName == "default email_alt"){$buttonName = "email_alt";} @endphp
-                                        @if($button->name !== 'icon')
+                                        @if($button && $button->name !== 'icon')
                                         <div class='row h-100 pb-0 mb-2 border rounded hvr-glow w-100' data-id="{{$link->id}}">
                                             <div class="d-flex ">
                             


### PR DESCRIPTION
This PR fixes a `500 Internal Server Error` caused by attempting to access the `name` property of a null `$button` object. A null check is added to ensure the property is only accessed when `$button` exists.

**Changes Made:**
- Added a null check for `$button` in `resources/views/studio/links.blade.php`.

**Why Needed:**
The error occurred after adding a vCard (or this is the last thing I can reminder), making the "Links" tab inaccessible. This fix prevents the error when `$button` is unexpectedly null.

Let me know if further adjustments are needed!